### PR TITLE
Fix: crash occured when couldnt open iconv

### DIFF
--- a/IGAutoString/IGAutoString.m
+++ b/IGAutoString/IGAutoString.m
@@ -15,7 +15,7 @@ static NSString* ig_convert_encoding(const char *src, size_t length, const char 
 {
     // Open Iconv
     iconv_t cd = iconv_open(tocode, fromcode);
-    if (cd < 0)
+    if (cd == (NSUInteger)(-1))
         return NULL;
 
     // Config Iconv - ignore illegal sequences


### PR DESCRIPTION
iconv_t is alias for void *, so we can present following:
void \* cd = -1;
    if (cd < 0) {
        NSLog(@"Less");
    } else {
        NSLog(@"Not less");
    }

Output will be - "Not less" as cd has value 0xffffffff
